### PR TITLE
flip sign using cfactor

### DIFF
--- a/syserol/tensor.py
+++ b/syserol/tensor.py
@@ -47,7 +47,8 @@ def reorient_factors(tFac):
     # Flip the subjects to be positive
     rMeans = np.sign(np.mean(tFac.factors[1], axis=0))
     agMeans = np.sign(np.mean(tFac.factors[2], axis=0))
-    tMeans = np.sign(np.mean(tFac.factors[3], axis=0))
+    # Flip time to be increasing always
+    tMeans = np.sign(tFac.cFactor[1,:] - tFac.cFactor[0,:])
     tFac.factors[0] *= (rMeans * agMeans * tMeans)[np.newaxis, :]
     tFac.factors[1] *= rMeans[np.newaxis, :]
     tFac.factors[2] *= agMeans[np.newaxis, :]


### PR DESCRIPTION
I think this is correct, based on just one run I did though. It appears to me that in our equation:
`    y = b + ((a - b) / (1.0 + np.power(x / c, d)))`
When a is positive and b is negative, we get a curve that is decreasing, and when a is negative and b is positive, our mode is increasing.
Thus, here we say make `np.sign` return -1 (we want to flip the axis) when [b - a] is negative (a decreasing curve). 
I'm just a bit worried about precision errors, but I do think this is the general rule that will work for flipping.